### PR TITLE
Change the file names expected for developer credentials

### DIFF
--- a/adminSDK/directory/AdminSDKDirectoryQuickstart/AdminSDKDirectoryQuickstart.cs
+++ b/adminSDK/directory/AdminSDKDirectoryQuickstart/AdminSDKDirectoryQuickstart.cs
@@ -37,12 +37,9 @@ namespace AdminSDKDirectoryQuickstart
             UserCredential credential;
 
             using (var stream =
-                new FileStream("client_secret.json", FileMode.Open, FileAccess.Read))
+                new FileStream("credentials.json", FileMode.Open, FileAccess.Read))
             {
-                string credPath = System.Environment.GetFolderPath(
-                    System.Environment.SpecialFolder.Personal);
-                credPath = Path.Combine(credPath, ".credentials/admin-directory_v1-dotnet-quickstart.json");
-
+                string credPath = "token.json";
                 credential = GoogleWebAuthorizationBroker.AuthorizeAsync(
                     GoogleClientSecrets.Load(stream).Secrets,
                     Scopes,

--- a/adminSDK/reports/AdminSDKReportsQuickstart/AdminSDKReportsQuickstart.cs
+++ b/adminSDK/reports/AdminSDKReportsQuickstart/AdminSDKReportsQuickstart.cs
@@ -37,12 +37,9 @@ namespace AdminSDKReportsQuickstart
             UserCredential credential;
 
             using (var stream =
-                new FileStream("client_secret.json", FileMode.Open, FileAccess.Read))
+                new FileStream("credentials.json", FileMode.Open, FileAccess.Read))
             {
-                string credPath = System.Environment.GetFolderPath(
-                    System.Environment.SpecialFolder.Personal);
-                credPath = Path.Combine(credPath, ".credentials/admin-reports_v1-dotnet-quickstart.json");
-
+                string credPath = "token.json";
                 credential = GoogleWebAuthorizationBroker.AuthorizeAsync(
                     GoogleClientSecrets.Load(stream).Secrets,
                     Scopes,

--- a/adminSDK/reseller/AdminSDKResellerQuickstart/AdminSDKResellerQuickstart.cs
+++ b/adminSDK/reseller/AdminSDKResellerQuickstart/AdminSDKResellerQuickstart.cs
@@ -37,12 +37,9 @@ namespace AdminSDKResellerQuickstart
             UserCredential credential;
 
             using (var stream =
-                new FileStream("client_secret.json", FileMode.Open, FileAccess.Read))
+                new FileStream("credentials.json", FileMode.Open, FileAccess.Read))
             {
-                string credPath = System.Environment.GetFolderPath(
-                    System.Environment.SpecialFolder.Personal);
-                credPath = Path.Combine(credPath, ".credentials/reseller-dotnet-quickstart.json");
-
+                string credPath = "token.json";
                 credential = GoogleWebAuthorizationBroker.AuthorizeAsync(
                     GoogleClientSecrets.Load(stream).Secrets,
                     Scopes,
@@ -78,7 +75,7 @@ namespace AdminSDKResellerQuickstart
             {
                 Console.WriteLine("No subscriptions found.");
             }
-            Console.Read();         
+            Console.Read();
         }
     }
 }

--- a/calendar/CalendarQuickstart/CalendarQuickstart.cs
+++ b/calendar/CalendarQuickstart/CalendarQuickstart.cs
@@ -40,12 +40,9 @@ namespace CalendarQuickstart
             UserCredential credential;
 
             using (var stream =
-                new FileStream("client_secret.json", FileMode.Open, FileAccess.Read))
+                new FileStream("credentials.json", FileMode.Open, FileAccess.Read))
             {
-                string credPath = System.Environment.GetFolderPath(
-                    System.Environment.SpecialFolder.Personal);
-                credPath = Path.Combine(credPath, ".credentials/calendar-dotnet-quickstart.json");
-
+                string credPath = "token.json";
                 credential = GoogleWebAuthorizationBroker.AuthorizeAsync(
                     GoogleClientSecrets.Load(stream).Secrets,
                     Scopes,

--- a/calendar/CalendarQuickstart/CalendarQuickstart.csproj
+++ b/calendar/CalendarQuickstart/CalendarQuickstart.csproj
@@ -77,7 +77,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Program.cs" />
+    <Compile Include="CalendarQuickstart.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/classroom/ClassroomQuickstart/ClassroomQuickstart.cs
+++ b/classroom/ClassroomQuickstart/ClassroomQuickstart.cs
@@ -40,12 +40,9 @@ namespace ClassroomQuickstart
             UserCredential credential;
 
             using (var stream =
-                new FileStream("client_secret.json", FileMode.Open, FileAccess.Read))
+                new FileStream("credentials.json", FileMode.Open, FileAccess.Read))
             {
-                string credPath = System.Environment.GetFolderPath(
-                    System.Environment.SpecialFolder.Personal);
-                credPath = Path.Combine(credPath, ".credentials/classroom.googleapis.com-dotnet-quickstart.json");
-
+                string credPath = "token.json";
                 credential = GoogleWebAuthorizationBroker.AuthorizeAsync(
                     GoogleClientSecrets.Load(stream).Secrets,
                     Scopes,

--- a/drive/DriveQuickstart/DriveQuickstart.cs
+++ b/drive/DriveQuickstart/DriveQuickstart.cs
@@ -40,12 +40,9 @@ namespace DriveQuickstart
             UserCredential credential;
 
             using (var stream =
-                new FileStream("client_secret.json", FileMode.Open, FileAccess.Read))
+                new FileStream("credentials.json", FileMode.Open, FileAccess.Read))
             {
-                string credPath = System.Environment.GetFolderPath(
-                    System.Environment.SpecialFolder.Personal);
-                credPath = Path.Combine(credPath, ".credentials/drive-dotnet-quickstart.json");
-
+                string credPath = "token.json";
                 credential = GoogleWebAuthorizationBroker.AuthorizeAsync(
                     GoogleClientSecrets.Load(stream).Secrets,
                     Scopes,

--- a/drive/DriveQuickstart/DriveQuickstart.csproj
+++ b/drive/DriveQuickstart/DriveQuickstart.csproj
@@ -77,7 +77,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Program.cs" />
+    <Compile Include="DriveQuickstart.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/drive/activity/DriveActivityQuickstart/DriveActivityQuickstart.cs
+++ b/drive/activity/DriveActivityQuickstart/DriveActivityQuickstart.cs
@@ -37,12 +37,9 @@ namespace DriveActivityQuickstart
             UserCredential credential;
 
             using (var stream =
-                new FileStream("client_secret.json", FileMode.Open, FileAccess.Read))
+                new FileStream("credentials.json", FileMode.Open, FileAccess.Read))
             {
-                string credPath = System.Environment.GetFolderPath(
-                    System.Environment.SpecialFolder.Personal);
-                credPath = Path.Combine(credPath, ".credentials/drive-dotnet-quickstart.json");
-
+                string credPath = "token.json";
                 credential = GoogleWebAuthorizationBroker.AuthorizeAsync(
                     GoogleClientSecrets.Load(stream).Secrets,
                     Scopes,
@@ -51,7 +48,7 @@ namespace DriveActivityQuickstart
                     new FileDataStore(credPath, true)).Result;
                 Console.WriteLine("Credential file saved to: " + credPath);
             }
-            
+
 			// Create Google Drive Activity API service.
             var service = new AppsactivityService(new BaseClientService.Initializer()
             {
@@ -89,7 +86,7 @@ namespace DriveActivityQuickstart
             {
                 Console.WriteLine("No recent activity.");
             }
-            Console.Read();         
+            Console.Read();
         }
     }
 }

--- a/gmail/GmailQuickstart/GmailQuickstart.cs
+++ b/gmail/GmailQuickstart/GmailQuickstart.cs
@@ -40,12 +40,9 @@ namespace GmailQuickstart
             UserCredential credential;
 
             using (var stream =
-                new FileStream("client_secret.json", FileMode.Open, FileAccess.Read))
+                new FileStream("credentials.json", FileMode.Open, FileAccess.Read))
             {
-                string credPath = System.Environment.GetFolderPath(
-                    System.Environment.SpecialFolder.Personal);
-                credPath = Path.Combine(credPath, ".credentials/gmail-dotnet-quickstart.json");
-
+                string credPath = "token.json";
                 credential = GoogleWebAuthorizationBroker.AuthorizeAsync(
                     GoogleClientSecrets.Load(stream).Secrets,
                     Scopes,

--- a/gmail/GmailQuickstart/GmailQuickstart.csproj
+++ b/gmail/GmailQuickstart/GmailQuickstart.csproj
@@ -77,7 +77,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Program.cs" />
+    <Compile Include="GmailQuickstart.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/sheets/SheetsQuickstart/SheetsQuickstart.cs
+++ b/sheets/SheetsQuickstart/SheetsQuickstart.cs
@@ -37,12 +37,9 @@ namespace SheetsQuickstart
             UserCredential credential;
 
             using (var stream =
-                new FileStream("client_secret.json", FileMode.Open, FileAccess.Read))
+                new FileStream("credentials.json", FileMode.Open, FileAccess.Read))
             {
-                string credPath = System.Environment.GetFolderPath(
-                    System.Environment.SpecialFolder.Personal);
-                credPath = Path.Combine(credPath, ".credentials/sheets.googleapis.com-dotnet-quickstart.json");
-
+                string credPath = "token.json";
                 credential = GoogleWebAuthorizationBroker.AuthorizeAsync(
                     GoogleClientSecrets.Load(stream).Secrets,
                     Scopes,

--- a/slides/SlidesQuickstart/SlidesQuickstart.cs
+++ b/slides/SlidesQuickstart/SlidesQuickstart.cs
@@ -37,12 +37,9 @@ namespace SlidesQuickstart
             UserCredential credential;
 
             using (var stream =
-                new FileStream("client_secret.json", FileMode.Open, FileAccess.Read))
+                new FileStream("credentials.json", FileMode.Open, FileAccess.Read))
             {
-                string credPath = System.Environment.GetFolderPath(
-                    System.Environment.SpecialFolder.Personal);
-                credPath = Path.Combine(credPath, ".credentials/slides.googleapis.com-dotnet-quickstart.json");
-
+                string credPath = "token.json";
                 credential = GoogleWebAuthorizationBroker.AuthorizeAsync(
                     GoogleClientSecrets.Load(stream).Secrets,
                     Scopes,

--- a/slides/SlidesQuickstart/SlidesQuickstart.csproj
+++ b/slides/SlidesQuickstart/SlidesQuickstart.csproj
@@ -70,7 +70,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Program.cs" />
+    <Compile Include="SlidesQuickstart.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tasks/TasksQuickstart/TasksQuickstart.cs
+++ b/tasks/TasksQuickstart/TasksQuickstart.cs
@@ -40,12 +40,9 @@ namespace TasksQuickstart
             UserCredential credential;
 
             using (var stream =
-                new FileStream("client_secret.json", FileMode.Open, FileAccess.Read))
+                new FileStream("credentials.json", FileMode.Open, FileAccess.Read))
             {
-                string credPath = System.Environment.GetFolderPath(
-                    System.Environment.SpecialFolder.Personal);
-                credPath = Path.Combine(credPath, ".credentials/tasks-dotnet-quickstart.json");
-
+                string credPath = "token.json";
                 credential = GoogleWebAuthorizationBroker.AuthorizeAsync(
                     GoogleClientSecrets.Load(stream).Secrets,
                     Scopes,

--- a/tasks/TasksQuickstart/TasksQuickstart.csproj
+++ b/tasks/TasksQuickstart/TasksQuickstart.csproj
@@ -77,7 +77,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Program.cs" />
+    <Compile Include="TasksQuickstart.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/vault/VaultQuickstart/VaultQuickstart.cs
+++ b/vault/VaultQuickstart/VaultQuickstart.cs
@@ -40,12 +40,9 @@ namespace VaultQuickstart
             UserCredential credential;
 
             using (var stream =
-                new FileStream("client_secret.json", FileMode.Open, FileAccess.Read))
+                new FileStream("credentials.json", FileMode.Open, FileAccess.Read))
             {
-                string credPath = System.Environment.GetFolderPath(
-                    System.Environment.SpecialFolder.Personal);
-                credPath = Path.Combine(credPath, ".credentials/vault.googleapis.com-dotnet-quickstart.json");
-
+                string credPath = "token.json";
                 credential = GoogleWebAuthorizationBroker.AuthorizeAsync(
                     GoogleClientSecrets.Load(stream).Secrets,
                     Scopes,


### PR DESCRIPTION
Change the file names expected for developer credentials and stored tokens to better match the name of the downloaded file.

Developer credentials: `client_secret.json` => `credentials.json`
User credentials / token: `credentials.json` => `token.json`

Also:

- Updated some incorrect file names in `.csproj` files.